### PR TITLE
Embeded Ruby Text changed from Orange to default base text color.

### DIFF
--- a/Solarized (dark).tmTheme
+++ b/Solarized (dark).tmTheme
@@ -653,7 +653,7 @@
 				<key>fontStyle</key>
 				<string>bold</string>
 				<key>foreground</key>
-				<string>#CB4B16</string>
+				<string>#839496</string>
 			</dict>
 		</dict>
 		<dict>

--- a/Solarized (light).tmTheme
+++ b/Solarized (light).tmTheme
@@ -653,7 +653,7 @@
 				<key>fontStyle</key>
 				<string>bold</string>
 				<key>foreground</key>
-				<string>#CB4B16</string>
+				<string>#657b83</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
Normal text in Embeded RuBy (`.erb`) files was rendering in Orange.

``` erb
<%= link_to "My profile", current_user %>
<span>Here some lovely text that shows up all in orange and is painfully annoying to read.</span>
```

This changes the text to Base 0 for the dark theme and Base 00 for the light theme.
