### PR TITLE
Changed foreground and caret in light theme to base00.

### DIFF
--- a/Solarized (light).tmTheme
+++ b/Solarized (light).tmTheme
@@ -12,9 +12,9 @@
 				<key>background</key>
 				<string>#FDF6E3</string>
 				<key>caret</key>
-				<string>#002B36</string>
+				<string>#657B83</string>
 				<key>foreground</key>
-				<string>#586E75</string>
+				<string>#657B83</string>
 				<key>invisibles</key>
 				<string>#EEE8D5</string>
 				<key>lineHighlight</key>


### PR DESCRIPTION
The foreground color in the light theme was base01 which is optional emphazised content. This changes it to base00 which is normal text, and also sets caret to the same, to match the dark theme.
