### PR TITLE
Set C function in dark theme to base1 instead of base01.

### DIFF
--- a/Solarized (dark).tmTheme
+++ b/Solarized (dark).tmTheme
@@ -1284,7 +1284,7 @@
 				<key>fontStyle</key>
 				<string></string>
 				<key>foreground</key>
-				<string>#586E75</string>
+				<string>#93A1A1</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
In the dark theme, C function names were base01, which is the color used for comments. This changes it to base1 which is optional emphazised content, to match the light theme.

I am not sure if it would be better to use base0 to make it look like the original vim screenshots, but then the light theme should be changed accordingly. On the other hand, it seems the C highlighting in those screenshots is partly due to how default vim fails to recognize function names.
