### PR TITLE
Added scope for Find In Files: File Name

### DIFF
--- a/Solarized (dark).tmTheme
+++ b/Solarized (dark).tmTheme
@@ -2021,6 +2021,17 @@
 				<string>#cb4b16</string>
 			</dict>
 		</dict>
+		<dict>
+			<key>name</key>
+			<string>Find In Files: File Name</string>
+			<key>scope</key>
+			<string>entity.name.filename.find-in-files</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#2AA198</string>
+			</dict>
+		</dict>
 	</array>
 	<key>uuid</key>
 	<string>A4299D9B-1DE5-4BC4-87F6-A757E71B1597</string>

--- a/Solarized (light).tmTheme
+++ b/Solarized (light).tmTheme
@@ -2021,6 +2021,17 @@
 				<string>#cb4b16</string>
 			</dict>
 		</dict>
+		<dict>
+			<key>name</key>
+			<string>Find In Files: File Name</string>
+			<key>scope</key>
+			<string>entity.name.filename.find-in-files</string>
+			<key>settings</key>
+			<dict>
+				<key>foreground</key>
+				<string>#2AA198</string>
+			</dict>
+		</dict>
 	</array>
 	<key>uuid</key>
 	<string>38E819D9-AE02-452F-9231-ECC3B204AFD7</string>


### PR DESCRIPTION
File names in the Find In Files view are not currently highlighted, making the results difficult to read. I created a scope for these filenames, using cyan (#2AA198) for both light and dark. After testing the entire palette,I found this to be the most aesthetically pleasing choice.

Screenshots of the updated color scheme:

![screenshot 2013-11-22 19 59 57](https://f.cloud.github.com/assets/2270905/1605493/c1449e38-53db-11e3-820a-1abb49560856.png)
![screenshot 2013-11-22 20 00 31](https://f.cloud.github.com/assets/2270905/1605495/c46a1b06-53db-11e3-9d24-afaa5b30a8a9.png)
