### PR TITLE
Added gutter background colors

### DIFF
--- a/Solarized (dark).tmTheme
+++ b/Solarized (dark).tmTheme
@@ -21,6 +21,8 @@
 				<string>#073642</string>
 				<key>selection</key>
 				<string>#EEE8D5</string>
+				<key>gutter</key>
+				<string>#073642</string>
 			</dict>
 		</dict>
 		<dict>

--- a/Solarized (light).tmTheme
+++ b/Solarized (light).tmTheme
@@ -21,6 +21,8 @@
 				<string>#EEE8D5</string>
 				<key>selection</key>
 				<string>#073642</string>
+				<key>gutter</key>
+				<string>#EEE8D5</string>
 			</dict>
 		</dict>
 		<dict>


### PR DESCRIPTION
I noticed on the http://ethanschoonover.com/solarized screenshots that the gutter has a different background color than the rest of the content. This commit adds these color definitions to the light and dark themes.
