### PR TITLE
Use same colors as Vim for selection

### DIFF
--- a/Solarized (dark).tmTheme
+++ b/Solarized (dark).tmTheme
@@ -20,9 +20,11 @@
 				<key>lineHighlight</key>
 				<string>#073642</string>
 				<key>selection</key>
-				<string>#586E75</string>
+				<string>#657B83</string>
 				<key>selectionForeground</key>
 				<string>#002B36</string>
+				<key>selectionBorder</key>
+				<string>#586E75</string>
 				<key>gutter</key>
 				<string>#073642</string>
 			</dict>

--- a/Solarized (light).tmTheme
+++ b/Solarized (light).tmTheme
@@ -20,9 +20,11 @@
 				<key>lineHighlight</key>
 				<string>#EEE8D5</string>
 				<key>selection</key>
-				<string>#93A1A1</string>
+				<string>#839496</string>
 				<key>selectionForeground</key>
 				<string>#FDF6E3</string>
+				<key>selectionBorder</key>
+				<string>#93A1A1</string>
 				<key>gutter</key>
 				<string>#EEE8D5</string>
 			</dict>


### PR DESCRIPTION
As noted in issue #28, the Solarized homepage does not appear to indicate what color should be used for selected text. This patch uses the same colors as in the Vim Solarized color scheme.

Using a fixed foreground and background color has the benefit of all text being readable when selected, but it also means that selected text is not syntax highlighted.

The other option would be to make the selection background closer to the normal background, and then use `selectionBorder` to make the selection visible.
