### PR TITLE
Adjust lineHighlight values for inverse_caret_state

### DIFF
--- a/Solarized (dark).tmTheme
+++ b/Solarized (dark).tmTheme
@@ -22,7 +22,7 @@
 				<key>invisibles</key>
 				<string>#586e75</string>
 				<key>lineHighlight</key>
-				<string>#073642</string>
+				<string>#1CD1FF12</string>
 				<key>selection</key>
 				<string>#2c4c55</string>
 				<key>selectionBorder</key>

--- a/Solarized (light).tmTheme
+++ b/Solarized (light).tmTheme
@@ -22,7 +22,7 @@
 				<key>invisibles</key>
 				<string>#eee8d5</string>
 				<key>lineHighlight</key>
-				<string>#eee8d5</string>
+				<string>#3F3D3812</string>
 				<key>selection</key>
 				<string>#eee8d5</string>
 				<key>selectionBorder</key>


### PR DESCRIPTION
I've adjusted the `lineHighlight` values by adding an alpha value and increasing (dark) / decreasing (light) the RGB values at the same time to make the "block cursor" more **visible** in `inverse_caret_state`, e.g. when using vi-emulation such as with the `Vintage` package.

**Note:** The cursor highlighting is *only* affected in `inverse_caret_state`, not if you're in regular insert mode with "overwrite" being active (press INS). However, this also affects highlighting of the current line in the gutter (on the line numbers, etc.), regardless of the `inverse_caret_state`.

Here's the visual difference of this PR:
![solarized_dark_beforeafter](https://cloud.githubusercontent.com/assets/5539930/21958347/bec66c58-daac-11e6-88d4-9b292ad9baab.gif)
![solarized_light_beforeafter](https://cloud.githubusercontent.com/assets/5539930/21958348/bff06958-daac-11e6-99bb-bef53387d603.gif)
