### PR TITLE
Add misspelling color

### DIFF
--- a/Solarized (dark).tmTheme
+++ b/Solarized (dark).tmTheme
@@ -23,6 +23,8 @@
 				<string>#586e75</string>
 				<key>lineHighlight</key>
 				<string>#1CD1FF12</string>
+				<key>misspelling</key>
+				<string>#dc322f</string>
 				<key>selection</key>
 				<string>#2c4c55</string>
 				<key>selectionBorder</key>

--- a/Solarized (light).tmTheme
+++ b/Solarized (light).tmTheme
@@ -23,6 +23,8 @@
 				<string>#eee8d5</string>
 				<key>lineHighlight</key>
 				<string>#3F3D3812</string>
+				<key>misspelling</key>
+				<string>#dc322f</string>
 				<key>selection</key>
 				<string>#eee8d5</string>
 				<key>selectionBorder</key>


### PR DESCRIPTION
Change the misspelling underline color to `#dc322f`.