### PR TITLE
Use yellow color for variables, to make Haskell syntax prettier

### DIFF
--- a/Solarized (dark).sublime-color-scheme
+++ b/Solarized (dark).sublime-color-scheme
@@ -264,6 +264,11 @@
             "foreground": "var(blue)"
         },
         {
+            "name": "Haskell: Variable",
+            "scope": "source.haskell variable",
+            "foreground": "var(yellow)"
+        },
+        {
             "name": "HTML: =",
             "scope": "text.html.basic meta.tag.other.html, text.html.basic meta.tag.any.html, text.html.basic meta.tag.block.any, text.html.basic meta.tag.inline.any, text.html.basic meta.tag.structure.any.html, text.html.basic source.js.embedded.html, punctuation.separator.key-value.html",
             "foreground": "var(base00)"


### PR DESCRIPTION
This tiny change seems to drastically improve Haskell syntax highlighting 😮 Please let me know if this should be done better — I'm not expert in how `.sublime-color-scheme` works.

---

Pay close attention on lines 60, 65 of first image — and lines 1169, 1181 of second image.

(**Left**: *before*, **Right**: *after*)

![image](https://user-images.githubusercontent.com/287532/52659244-2a223800-2efd-11e9-9faf-346b78380b46.png)

![image](https://user-images.githubusercontent.com/287532/52659364-6786c580-2efd-11e9-9e69-c7a47c8d425e.png)
