### PR TITLE
Fix Go's variables

### DIFF
--- a/Solarized (dark).sublime-color-scheme
+++ b/Solarized (dark).sublime-color-scheme
@@ -540,6 +540,13 @@
             "foreground": "var(base0)"
         },
 
+        // Go
+        {
+            "name": "Go Variables",
+            "scope": "variable.other.go, variable.other.member.go, variable.other.member.declaration.go, variable.other.constant.declaration.go",
+            "foreground": "var(base0)"
+        },
+
         // Sublime Merge
         {
             "scope": "diff.deleted",

--- a/Solarized (light).sublime-color-scheme
+++ b/Solarized (light).sublime-color-scheme
@@ -540,6 +540,13 @@
             "foreground": "var(base00)"
         },
 
+        // Go
+        {
+            "name": "Go Variables",
+            "scope": "variable.other.go, variable.other.member.go, variable.other.member.declaration.go, variable.other.constant.declaration.go",
+            "foreground": "var(base00)"
+        },
+
         // Sublime Merge
         {
             "scope": "diff.deleted",


### PR DESCRIPTION
The Go syntax causes some schemes to colour _all_ variables of any kind
with the "variable" colour. This can also be seen with the
built-in "Sixteen" colour scheme (and, indeed, with the original Base16
it came from). Without the change in this commit there is no instance
of a variable with foreground which contrasts with, say, Python where
most variables appear with the foreground colour. In the case of
Solarized light it's a "sea of blue".

An example in Python shows the expected behaviour.

    if not os.path.exists(repo_name):
        return False
    for fname in ["refs", "HEAD", "objects", "hooks"]:

"os", "path", "repo_name" and "fname" are all set to the default
 foreground.

This Go code, however does not.

  	fileHeader := make([]byte, exifHeaderSize)
	if _, err := data.Read(fileHeader); err != nil {

"fileHeader", "exifHeaderSize", "err" (both instances) and "data" all
display as the variable colour (blue, in the case of Solarized light
theme).

I'm not expecting the syntax file to change any time soon (changing the
way the syntax definition works could have drastic downstream effects).
Working around it in the scheme seems like the right approach. I
believe JavaScript has a similar variable workaround.